### PR TITLE
Set default crop option when using only height and width

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export function image(node: HTMLImageElement, parameters: ImageParameters) {
   let { src, options, bind, lazy, step } = parameters
   log('Image Declared', parameters)
   options = options ?? {}
+  options.crop = options.crop ?? 'fill'
   step = step ?? 200
   lazy = lazy ?? true
 


### PR DESCRIPTION
This PR will handle resize transforms properly by defaulting `crop` to `'fill'` when no `crop` option is passed.

Tested by linking my fork locally to my project.

Closes #8 