### PR TITLE
readme update to include npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ There is an [official integration coming](https://github.com/cloudinary/cloudina
 ```bash
 yarn add svelte-cloudinary
 ```
+```bash
+npm install svelte-cloudinary
+```
 
 ```svelte
 <script>


### PR DESCRIPTION
as i understand, a lot of people coming into Svelte are not seasoned js developers. the package ecosystem can def be pretty overwhelming, so i figured it was a good idea to include the npm installation in the docs, since your package is on there and it is the defacto package manager. it's not a very good idea to mix package managers, so this might save some people who didn't look up the npm registry from a potential headache. this repo works great, since the official cloudinary repo still gives SSR issues w kit.